### PR TITLE
fix: install task command in stress test CI workflow

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo
 
+      - name: Install Task
+        run: |
+          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
       - name: Run stress tests
         run: |
           echo "Running stress tests..."


### PR DESCRIPTION
## Summary
- Fixes the failing stress test CI jobs by installing the `task` command before running tests
- The stress tests were failing with exit code 127 (command not found) because `task` was not available in the GitHub Actions runner

## Test plan
- [x] Verified stress tests run successfully locally with `task test:stress`
- [ ] CI workflow should pass after this change

🤖 Generated with [Claude Code](https://claude.ai/code)