### PR TITLE
fix: remove Nancy vulnerability scanner from security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,24 +44,3 @@ jobs:
       uses: actions/dependency-review-action@v4
       with:
         fail-on-severity: moderate
-
-  nancy:
-    runs-on: ubuntu-latest
-    name: Nancy (Sonatype OSS Index)
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-
-    - name: Generate go.list
-      run: go list -json -deps ./... > go.list
-
-    - name: Run Nancy
-      uses: sonatype-nexus-community/nancy-github-action@main
-      with:
-        nancyCommand: sleuth --loud


### PR DESCRIPTION
## Summary
- Removes Nancy vulnerability scanner which is failing with APK retrieval errors
- Nancy is redundant since we already have govulncheck (Go's official vulnerability scanner)
- Keeps govulncheck and dependency-review for comprehensive security scanning

## Why remove Nancy?
1. **Redundant**: We already have govulncheck which is the official Go vulnerability scanner maintained by the Go team
2. **Failing**: Nancy is failing in CI with APK-related errors
3. **Maintenance**: One less third-party tool to maintain and debug

## What remains for security scanning?
- `govulncheck`: Official Go vulnerability scanner
- `dependency-review`: GitHub's dependency review action for PR changes

## Test plan
- [ ] Security workflow should pass without Nancy
- [ ] govulncheck continues to run successfully
- [ ] dependency-review continues to work on PRs

🤖 Generated with [Claude Code](https://claude.ai/code)