### PR TITLE
Fix: Flaky concurrent publisher stress test (CON-74)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
   test:integration:
     desc: Run integration tests
     cmds:
-      - go run github.com/onsi/ginkgo/v2/ginkgo -v ./test/integration
+      - go run github.com/onsi/ginkgo/v2/ginkgo -p -v ./test/integration
 
   test:benchmark:
     desc: Run performance benchmarks
@@ -34,7 +34,7 @@ tasks:
   test:stress:
     desc: Run stress tests
     cmds:
-      - go run github.com/onsi/ginkgo/v2/ginkgo -v ./stress_tests
+      - go run github.com/onsi/ginkgo/v2/ginkgo -p -v ./stress_tests
 
   test:coverage:
     desc: Run tests with coverage report

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -36,7 +36,7 @@ var _ = Describe("NATS Stress Tests", func() {
 		// Increase limits for stress testing
 		opts.MaxPayload = 10 * 1024 * 1024 // 10MB
 		opts.MaxPending = 10 * 1024 * 1024 // 10MB
-		
+
 		// Increase handshake timout b/c registering many concurrent publishers creates a thundering herd problem
 		opts.AuthTimeout = 10
 

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -36,7 +36,7 @@ var _ = Describe("NATS Stress Tests", func() {
 		// Increase limits for stress testing
 		opts.MaxPayload = 10 * 1024 * 1024 // 10MB
 		opts.MaxPending = 10 * 1024 * 1024 // 10MB
-		12
+		
 		// Increase handshake timout b/c registering many concurrent publishers creates a thundering herd problem
 		opts.AuthTimeout = 10
 
@@ -207,7 +207,7 @@ output:
 			// Verify all messages received
 			Eventually(func() int64 {
 				return received.Load()
-			}, 60*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
+			}, 30*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
 
 			rate := float64(totalMessages) / duration.Seconds()
 

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -77,6 +77,11 @@ var _ = Describe("NATS Stress Tests", func() {
 
 			// Producer configuration with high throughput
 			producerConfig := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   generate:
     count: %d
@@ -154,6 +159,11 @@ output:
 					defer GinkgoRecover()
 
 					config := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   generate:
     count: %d
@@ -186,6 +196,9 @@ output:
 						publishErrors.Add(1)
 					}
 				}(i)
+				if i%10 == 0 {
+					time.Sleep(10 * time.Millisecond)
+				}
 			}
 
 			wg.Wait()
@@ -232,6 +245,11 @@ output:
 
 			// Producer configuration - generate 1MB messages
 			producerConfig := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   generate:
     count: %d
@@ -295,6 +313,11 @@ output:
 
 			// Consumer configuration
 			consumerConfig := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   nats_jetstream:
     urls: ["%s"]
@@ -346,6 +369,11 @@ output:
 
 			// Producer configuration
 			producerConfig := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   generate:
     count: %d
@@ -447,6 +475,11 @@ output:
 
 					for j := 0; j < updatesPerKey; j++ {
 						config := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   generate:
     count: 1
@@ -548,6 +581,11 @@ output:
 			go func() {
 				for sent.Load() < int64(messageCount) {
 					config := fmt.Sprintf(`
+logger:
+  level: warn
+  format: json
+  add_timestamp: true
+
 input:
   generate:
     count: 100

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -207,7 +207,7 @@ output:
 			// Verify all messages received
 			Eventually(func() int64 {
 				return received.Load()
-			}, 60*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
+			}, 120*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
 
 			rate := float64(totalMessages) / duration.Seconds()
 

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -207,7 +207,7 @@ output:
 			// Verify all messages received
 			Eventually(func() int64 {
 				return received.Load()
-			}, 30*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
+			}, 60*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
 
 			rate := float64(totalMessages) / duration.Seconds()
 

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -193,15 +193,15 @@ output:
 					}
 
 					stream, err := builder.Build()
-					if err != nil {
-						publishErrors.Add(1)
-						<-queue // Release slot on error
-						return
-					}
 
 					// Release queue slot after stream is built and the handshake with the nats server is successful
 					// but _before_ we kick of the stream since we want to run these streams concurrently
 					<-queue
+
+					if err != nil {
+						publishErrors.Add(1)
+						return
+					}
 
 					// Now all streams can run concurrently
 					if err := stream.Run(context.Background()); err != nil {

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -36,7 +36,7 @@ var _ = Describe("NATS Stress Tests", func() {
 		// Increase limits for stress testing
 		opts.MaxPayload = 10 * 1024 * 1024 // 10MB
 		opts.MaxPending = 10 * 1024 * 1024 // 10MB
-
+		12
 		// Increase handshake timout b/c registering many concurrent publishers creates a thundering herd problem
 		opts.AuthTimeout = 10
 
@@ -207,7 +207,7 @@ output:
 			// Verify all messages received
 			Eventually(func() int64 {
 				return received.Load()
-			}, 30*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
+			}, 60*time.Second, 100*time.Millisecond).Should(Equal(int64(totalMessages)))
 
 			rate := float64(totalMessages) / duration.Seconds()
 

--- a/stress_tests/nats_stress_test.go
+++ b/stress_tests/nats_stress_test.go
@@ -37,6 +37,9 @@ var _ = Describe("NATS Stress Tests", func() {
 		opts.MaxPayload = 10 * 1024 * 1024 // 10MB
 		opts.MaxPending = 10 * 1024 * 1024 // 10MB
 
+		// Increase handshake timout b/c registering many concurrent publishers creates a thundering herd problem
+		opts.AuthTimeout = 10
+
 		var err error
 		srv = test.RunServer(&opts)
 		Expect(srv).NotTo(BeNil())
@@ -196,9 +199,6 @@ output:
 						publishErrors.Add(1)
 					}
 				}(i)
-				if i%10 == 0 {
-					time.Sleep(10 * time.Millisecond)
-				}
 			}
 
 			wg.Wait()


### PR DESCRIPTION
https://linear.app/synadia/issue/CON-74

**TLDR;**

- set Benthos log level to `warn` to reduce logging noise 
- use channel to create publishers sequentially for concurrent publisher test. This prevents a thundering herd and dropped messages.
- reduce timeout for concurrent publishers test to 5 seconds, because it's still fast even though it handles publishers sequentially
- run tests in parallel. 


To verify on a local dev machine, run a few instances of the stress tests concurrently: 

```bash
task test:stress
```

Stress tests that passed on this branch: 

- https://github.com/synadia-io/connect-runtime-wombat/actions/runs/16781474744
- https://github.com/synadia-io/connect-runtime-wombat/actions/runs/16781472634
- https://github.com/synadia-io/connect-runtime-wombat/actions/runs/16781470234
- https://github.com/synadia-io/connect-runtime-wombat/actions/runs/16781467538
- https://github.com/synadia-io/connect-runtime-wombat/actions/runs/16781464466
- https://github.com/synadia-io/connect-runtime-wombat/actions/runs/16781461897



**Problem**

`Concurrent Publisher Stress Tests` test registers 100 Benthos stream processors with a nats output. The nats test server gets overwhelmed when dealing with 100 concurrent handshakes. 

**Solution**

Create publishers for the concurrent publisher test sequentially. Test is still fast enough.