### PR TITLE
fix: use proper list/string for kind/type fields.

### DIFF
--- a/.connect/sinks/elasticsearch_v8.yaml
+++ b/.connect/sinks/elasticsearch_v8.yaml
@@ -18,12 +18,12 @@ fields:
       description: A list of URLs to connect to. If an item of the list contains commas it will be expanded into multiple URLs.
       examples:
         - - http://localhost:9200
-      kind: scalar
+      kind: list
       label: urls
       name: urls
       optional: false
       path: urls
-      type: array
+      type: string
     - default: ""
       description: The index to place messages.
       kind: scalar
@@ -181,12 +181,12 @@ fields:
               path: tls.client_certs[].password
               secret: true
               type: string
-          kind: scalar
+          kind: list
           label: client_certs
           name: client_certs
           optional: true
           path: tls.client_certs
-          type: array
+          type: object
       kind: scalar
       label: tls
       name: tls
@@ -294,12 +294,12 @@ fields:
                     format: lines
             - - archive:
                     format: json_array
-          kind: scalar
+          kind: list
           label: processors
           name: processors
           optional: false
           path: batching.processors
-          type: array
+          type: object
       kind: scalar
       label: batching
       name: batching

--- a/.connect/sinks/ww_mqtt_3.yml
+++ b/.connect/sinks/ww_mqtt_3.yml
@@ -7,12 +7,12 @@ description: "Pushes messages to an MQTT broker.\n\nUses mqtt output component f
 fields:
     - default: '["tcp://localhost:1883"]'
       description: List of MQTT broker URLs to connect to.
-      kind: scalar
+      kind: list
       label: urls
       name: urls
       optional: true
       path: urls
-      type: array
+      type: string
     - default: '""'
       description: Unique client identifier. If empty, one will be generated.
       kind: scalar

--- a/.connect/sources/ww_mqtt_3.yml
+++ b/.connect/sources/ww_mqtt_3.yml
@@ -48,12 +48,12 @@ description: |+
 fields:
     - default: '["tcp://localhost:1883"]'
       description: List of MQTT broker URLs to connect to.
-      kind: scalar
+      kind: list
       label: urls
       name: urls
       optional: true
       path: urls
-      type: array
+      type: string
     - default: '""'
       description: Unique client identifier. If empty, one will be generated.
       kind: scalar


### PR DESCRIPTION
- added validation for spec fields that depend on each other. Such as `kind: list` & `type: string` for example. 
- fix those for elasticsearch and mqtt components. 